### PR TITLE
Optimize batched inference in test script

### DIFF
--- a/test.py
+++ b/test.py
@@ -5,8 +5,6 @@ import json
 import pandas as pd
 import numpy as np
 import tensorflow as tf
-from tqdm import tqdm
-from tensorflow.keras.preprocessing import image
 
 # 모델 로드
 model = tf.keras.models.load_model("car_model_classifier.h5")
@@ -22,20 +20,26 @@ class_list = [index_to_class[i] for i in range(len(index_to_class))]  # 정렬�
 TEST_DIR = "open/test"
 image_paths = sorted(glob(os.path.join(TEST_DIR, "*.jpg")))  # 정렬은 ID 순서 유지 위함
 
-results = []
+# 데이터셋 생성 및 성능 향상을 위한 prefetch 적용
+test_dataset = tf.keras.preprocessing.image_dataset_from_directory(
+    TEST_DIR,
+    labels=None,
+    image_size=(224, 224),
+    batch_size=32,
+    shuffle=False
+).map(lambda x: x / 255.0).prefetch(tf.data.AUTOTUNE)
 
-# 예측 반복
-for path in tqdm(image_paths, desc="이미지 예측 중"):
-    img = image.load_img(path, target_size=(224, 224))
-    x = image.img_to_array(img)
-    x = np.expand_dims(x, axis=0) / 255.0
+# 배치 단위 예측으로 속도 향상
+preds = model.predict(test_dataset, verbose=0)
+max_indices = np.argmax(preds, axis=1)
+one_hot = np.zeros_like(preds)
+one_hot[np.arange(len(preds)), max_indices] = 1.0
 
-    pred = model.predict(x, verbose=0)[0]
-    one_hot = np.zeros_like(pred)
-    one_hot[np.argmax(pred)] = 1.0
-
-    results.append([os.path.splitext(os.path.basename(path))[0]] + one_hot.tolist())
-
+# ID와 예측 결과 매핑
+results = [
+    [os.path.splitext(os.path.basename(path))[0]] + one_hot[i].tolist()
+    for i, path in enumerate(image_paths)
+]
 
 # 결과 저장
 df = pd.DataFrame(results, columns=["ID"] + class_list)


### PR DESCRIPTION
## Summary
- speed up prediction by batching and prefetching test images

## Testing
- `python -m py_compile test.py`
- `python test.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_689343c4bff88329a32c7dd6fc90f601